### PR TITLE
Refactor node for easier to rotation.

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -1,7 +1,6 @@
 #![allow(dead_code)]
-use ::std::cmp::Ordering;
-
-type Child<K, V> = Option<Box<Node<K, V>>>;
+use std::cmp::Ordering;
+use std::default::Default;
 
 pub trait KV: Sized + PartialEq {}
 
@@ -10,14 +9,29 @@ pub trait KV: Sized + PartialEq {}
 pub struct Node<K, V>
     where K: Ord
 {
+    inner: Option<Box<InnerNode<K, V>>>,
+}
+
+impl<K: Ord, V> Default for Node<K, V> {
+    fn default() -> Self {
+        Node { inner: None }
+    }
+}
+
+
+/// A node in a binary search tree
+#[derive(Debug, PartialEq, Clone)]
+struct InnerNode<K, V>
+    where K: Ord
+{
     /// This node's key
     key: K,
     /// This node's value
     value: V,
     /// Left child
-    left: Child<K, V>,
+    left: Node<K, V>,
     /// Right child
-    right: Child<K, V>,
+    right: Node<K, V>,
 }
 
 impl<K, V> Node<K, V>
@@ -25,55 +39,56 @@ impl<K, V> Node<K, V>
 {
     pub fn new(k: K, v: V) -> Node<K, V> {
         Node {
-            key: k,
-            value: v,
-            left: None,
-            right: None,
+            inner: Some(Box::new(InnerNode {
+                                     key: k,
+                                     value: v,
+                                     left: Node::default(),
+                                     right: Node::default(),
+                                 })),
         }
     }
 
     pub fn insert(&mut self, key: K, value: V) -> Option<V> {
-        match self.key.cmp(&key) {
-            Ordering::Less => {
-                match self.right {
-                    None => {
-                        self.right = Some(Box::new(Node::new(key, value)));
-                        None
-                    }
-                    Some(ref mut right) => right.insert(key, value),
+        match self.inner {
+            None => {
+                *self = Self::new(key, value);
+                None
+            }
+            Some(ref mut inner) => {
+                match inner.key.cmp(&key) {
+                    Ordering::Greater => inner.left.insert(key, value),
+                    Ordering::Equal => Some(::std::mem::replace(&mut inner.value, value)),
+                    Ordering::Less => inner.right.insert(key, value),
                 }
             }
-            Ordering::Greater => {
-                match self.left {
-                    None => {
-                        self.left = Some(Box::new(Node::new(key, value)));
-                        None
-                    }
-                    Some(ref mut left) => left.insert(key, value),
-                }
-            }
-            Ordering::Equal => Some(::std::mem::replace(&mut self.value, value)),
         }
     }
 
     pub fn get(&self, key: &K) -> Option<&V> {
-        match self.key.cmp(key) {
-            Ordering::Equal => Some(&self.value),
-            Ordering::Less => self.right.as_ref().and_then(|node| node.get(key)),
-            Ordering::Greater => self.left.as_ref().and_then(|node| node.get(key)),
+        match self.inner {
+            None => None,
+            Some(ref inner) => {
+                match inner.key.cmp(key) {
+                    Ordering::Greater => inner.left.get(key),
+                    Ordering::Equal => Some(&inner.value),
+                    Ordering::Less => inner.right.get(key),
+                }
+            }
         }
     }
 
-    pub fn children(&self) -> usize {
-        self.left.as_ref().map_or(0, |node| 1 + node.children()) +
-        self.right.as_ref().map_or(0, |node| 1 + node.children())
+    pub fn len(&self) -> usize {
+        match self.inner {
+            None => 0,
+            Some(ref inner) => inner.left.len() + 1 + inner.right.len(),
+        }
     }
 }
 
 
 #[cfg(test)]
 mod tests {
-    use node::Node;
+    use node::{Node, InnerNode};
 
     #[test]
     fn node_eq_pass() {
@@ -112,13 +127,15 @@ mod tests {
         node_root.insert(2, 'c');
 
         let node_root_1 = Node {
-            left: Some(Box::new(Node::new(0, 'a'))),
-            right: Some(Box::new(Node::new(2, 'c'))),
-            key: 1,
-            value: 'b',
+            inner: Some(Box::new(InnerNode {
+                                     left: Node::new(0, 'a'),
+                                     right: Node::new(2, 'c'),
+                                     key: 1,
+                                     value: 'b',
+                                 })),
         };
         assert_eq!(node_root, node_root_1);
-        assert_eq!(node_root.children(), 2);
+        assert_eq!(node_root.len(), 3);
     }
 
     #[test]
@@ -133,7 +150,6 @@ mod tests {
         let mut node_root = Node::new(1, 'b');
         node_root.insert(0, 'a');
         node_root.insert(2, 'c');
-
         assert_eq!(node_root.get(&0), Some(&'a'));
         assert_eq!(node_root.get(&1), Some(&'b'));
         assert_eq!(node_root.get(&2), Some(&'c'));

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,6 +1,7 @@
 use node::*;
+use std::default::Default;
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct Tree<K, V>
     where K: Ord
 {
@@ -8,14 +9,20 @@ pub struct Tree<K, V>
     root: Option<Node<K, V>>,
 }
 
-impl<K, V> Tree<K, V>
-    where K: Ord
-{
-    pub fn new() -> Tree<K, V> {
+impl<K: Ord, V> Default for Tree<K, V> {
+    fn default() -> Self {
         Tree {
             size: 0,
             root: None,
         }
+    }
+}
+
+impl<K, V> Tree<K, V>
+    where K: Ord
+{
+    pub fn new() -> Tree<K, V> {
+        Tree::default()
     }
 
     pub fn insert(&mut self, key: K, value: V) -> Option<V> {


### PR DESCRIPTION
By having `Node` only contain an optional `InnerNode`, we can later completely replace `Tree` with `Node`.